### PR TITLE
feat(security): Stage 2 - Enable GuardDuty RDS Protection

### DIFF
--- a/cloudformation/threat-detection/guardduty-rds-protection.yaml
+++ b/cloudformation/threat-detection/guardduty-rds-protection.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Mission Enable RDS Protection: Enables GuardDuty and RDS Protection Feature (Stage 2)'
+
+Parameters:
+  DetectorId:
+    Type: String
+    Description: The ID of the existing GuardDuty Detector.
+
+Resources:
+  GuardDutyRDSProtectionFeature:
+    Type: AWS::GuardDuty::Detector
+    Properties:
+      Enable: True
+      DataSources: 
+        S3Logs:
+          Enable: True # Recommended to keep enabled
+      Features:
+        - Name: S3_DATA_EVENTS
+          Status: ENABLED # Recommended to keep enabled
+        - Name: EKS_AUDIT_LOGS
+          Status: ENABLED # Recommended to keep enabled
+        - Name: RDS_LOGIN_EVENTS
+          Status: ENABLED
+
+Outputs:
+  GuardDutyDetectorId:
+    Description: The ID of the configured GuardDuty Detector.
+    Value: !Ref DetectorId
+  RDSProtectionStatus:
+    Description: The status of the GuardDuty RDS Protection feature.
+    Value: 'ENABLED'


### PR DESCRIPTION
## 📋 Summary
This PR addresses Stage 2 of `mission-enable-rds-protection` by deploying the CloudFormation stack to enable the GuardDuty for RDS Protection feature.

## 🔧 Changes
- Deploys `cloudformation/threat-detection/guardduty-rds-protection.yaml`.
- Enables the `RDS_LOGIN_EVENTS` feature in the account's GuardDuty detector.

## 💰 Cost Impact
- Enables a new GuardDuty feature which will incur costs based on RDS login event volume. See Cost Analysis report for details.

## 🔒 Security
- This is a direct security enhancement, providing threat detection for RDS login activity.

## 🔄 Rollback
- Revert this PR. The deployment workflow will update the GuardDuty detector, disabling the feature.