### PR TITLE
feat(compliance): Stage 2 - Deploy RDS Config Rules

### DIFF
--- a/cloudformation/data-protection-and-logging/rds-config-rules.yaml
+++ b/cloudformation/data-protection-and-logging/rds-config-rules.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Mission Enable RDS Protection: AWS Config rules for RDS logging and encryption (Stage 2/3)'
+
+Resources:
+  RdsEncryptionEnabledRule:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: rds-storage-encrypted
+      Description: 'Checks if Amazon RDS DB instances are configured for storage encryption.'
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBInstance
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_STORAGE_ENCRYPTED
+
+  RdsLoggingEnabledRule:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: rds-logs-exported
+      Description: 'Checks if RDS DB instances have all specified log types exported to CloudWatch Logs.'
+      InputParameters:
+        logTypes: 'audit,error,general,slowquery'
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::RDS::DBInstance
+      Source:
+        Owner: AWS
+        SourceIdentifier: RDS_LOGGING_ENABLED
+
+Outputs:
+  RdsEncryptionRuleName:
+    Value: !Ref RdsEncryptionEnabledRule
+  RdsLoggingRuleName:
+    Value: !Ref RdsLoggingEnabledRule


### PR DESCRIPTION
## 📋 Summary
This PR addresses Stage 2 of `mission-enable-rds-protection` by deploying AWS Config rules to monitor RDS encryption and logging.

## 🔧 Changes
- Deploys `cloudformation/data-protection-and-logging/rds-config-rules.yaml`.
- Creates two AWS Config rules:
  - `rds-storage-encrypted`: Checks that all RDS instances have encryption at rest enabled.
  - `rds-logs-exported`: Checks that RDS instances are exporting all required logs to CloudWatch.

## 💰 Cost Impact
- Minor cost associated with AWS Config rule evaluations.

## 🔒 Security
- Provides continuous monitoring for key data protection and audit controls.

## 🔄 Rollback
- Revert this PR. The deployment workflow will delete the AWS Config rules.